### PR TITLE
Remove "Good First issue Hacktoberfest-2020" repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@
 - [First PR](https://github.com/Ishaan28malik/Hacktoberfest-2020)
 - [Flexbox Froggy](https://github.com/thomaspark/flexboxfroggy)
 - [GitHub Writes Code](https://github.com/JohnPhamous/GitHub-Writes-Code)
-- [Good First issue Hacktoberfest-2020](https://github.com/Py-Contributors/Hacktoberfest-2020)
 - [HBD](https://github.com/vinitshahdeo/HBD)
 - [Hack-Day](https://github.com/lugnitdgp/Hack-Day)
 - [Hacktoberfest Animations](https://github.com/NiallEccles/Hacktoberfest-animations)


### PR DESCRIPTION
Removed the mentioned repository from the README.md document as it is ineligible with Hacktoberfest.
