### PR TITLE
fixed link to contributing guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 If you want to add a project to this list, please make sure that:
 
-- [ ] You read the [contributing guide](#CONTRIBUTING.md)
+- [ ] You read the [contributing guide](https://github.com/OtacilioN/awesome-hacktoberfest-2020/blob/master/CONTRIBUTING.md)
 - [ ] The project can't be just an "add your name" or simply + 1 contribution to hacktoberfest
 - [ ] Place them in alphabetical order
 - [ ] One repository per PR/contribution - _avoid conflicts and simplify review_


### PR DESCRIPTION
fixed link to contributing guide. Right now, contributing guide is not opening, so I've fixed it by putting whole URL path to pull request template

## Contributing

If you want to add a project to this list, please make sure that:

- [x] You read the [contributing guide](#CONTRIBUTING.md)
- [ ] The project can't be just an "add your name" or simply + 1 contribution to hacktoberfest
- [ ] Place them in alphabetical order
- [ ] One repository per PR/contribution - _avoid conflicts and simplify review_
- [x] Your pull request is not spammy just adding an empty line, otherwise it will be marked as invalid and not count to hacktoberfest.

If they meet the requirements above, feel free to create a PR. Happy Hacking! :sparkles: 
